### PR TITLE
Update default model names

### DIFF
--- a/client/src/store.js
+++ b/client/src/store.js
@@ -9,8 +9,8 @@ let lastPredictionInput = localStorage.getItem('lastPredictionInput') || "public
 let lastSearchInput = localStorage.getItem('lastSearchInput') || "public class Test {\n    public static void main(String[] args) {\n\n    }\n}";
 
 // selected models
-let currentModel = localStorage.getItem('currentModel') || 'langmodel-large-split_10k_1_512_190926.120146';
-let currentModel2 = localStorage.getItem('currentModel2') || 'langmodel-large-split_10k_1_512_190926.120146';
+let currentModel = localStorage.getItem('currentModel') || 'langmodel-large-split_10k_1_512_190926.120146_new';
+let currentModel2 = localStorage.getItem('currentModel2') || 'langmodel-large-split_10k_1_512_190926.120146_new';
 
 // tokenTypes and metrics
 let tokenTypesJson = localStorage.getItem('tokenTypesJson') || `["all", "only_comments", "all_but_comments"]`;


### PR DESCRIPTION
Some models have a `_new` prefix now:

```
$ curl 'https://www.inf.unibz.it/~hbabii/pretrained_models_list'

dev_10k_1_10_190923.132328_new
langmodel-large-split_10k_2_1024_191007.112241_-_langmodel-large- 
split_10k_2_1024_191022.141344_new
langmodel-small-split_10k_1_512_190906.154943_new
langmodel-large-split_10k_1_512_190926.120146_new
langmodel-small-split-reversed_10k_1_512_200117.095729
```

Otherwise, webapp gets HTTP 500 request from the backend on looking up non-existant models by name:

<details>
  <summary>Full stack trace</summary >

```
2020-04-28 19:01:20,390 [werkzeug] INFO: 127.0.0.1 - - [28/Apr/2020 19:01:20] "POST /api/languagemodel HTTP/1.1" 500 -
Traceback (most recent call last):
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/app.py", line 2463, in __call__
    return self.wsgi_app(environ, start_response)
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/app.py", line 2449, in wsgi_app
    response = self.handle_exception(e)
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/app.py", line 1866, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "~/gigacode/.venv/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "~/gigacode/lm-powered-backend/webservice.py", line 67, in api_languagemodel
    return entropy_controller.get_entropies(request, models)
  File "~/gigacode/lm-powered-backend/controller/entropy_controller.py", line 198, in get_entropies
    selected_model = models[selected_model_name]
KeyError: 'langmodel-large-split_10k_1_512_190926.120146'
```
</details>
